### PR TITLE
Gracefully handle JWT expiration

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,7 +24,7 @@ export function middleware(req: NextRequest) {
       if (value.user.type != 2) {
         return NextResponse.next();
       } else {
-        return NextResponse.redirect(new URL("/projects", req.url));
+        return NextResponse.redirect(new URL("/projects", req.url)); // Replace with /dashboard when it exists
       }
     } else {
       return NextResponse.next();


### PR DESCRIPTION
# Overview of Issue 40

There are several routes that completely break in the event a JWT expires. This should be handled safely and instead redirect the user back to the login page. 

Made changes to the middleware.ts to check for the validation token. If no validation token exists, redirects to the login route. 

middleware.ts now applies to all routes besides the random routes like /_next.

# Requirements 

- [x] Failed JWT session retrieval should result in the user being redirected to login