### PR TITLE
Aakash Connect Request new account frontend to backend

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,3 +1,4 @@
+import { ReactQueryProvider } from "@/components/providers/ReactQueryProvider";
 import InstructionPanel from "@/components/auth/InstructionPanel";
 import Image from "next/image";
 
@@ -7,23 +8,25 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex h-screen">
-      <div className="flex w-[60%] flex-col">
-        <div className="w-full p-5">
-          <Image
-            src="/InfraJuno.png"
-            alt="Juno"
-            width={180}
-            height={30}
-            className="mb-10"
-          />
+    <ReactQueryProvider>
+      <div className="flex h-screen">
+        <div className="flex w-[60%] flex-col">
+          <div className="w-full p-5">
+            <Image
+              src="/InfraJuno.png"
+              alt="Juno"
+              width={180}
+              height={30}
+              className="mb-10"
+            />
+          </div>
+          <div className="flex flex-col items-center">{children}</div>
         </div>
-        <div className="flex flex-col items-center">{children}</div>
-      </div>
 
-      <div className="relative w-[40%] overflow-visible bg-neutral-950">
-        <InstructionPanel />
+        <div className="relative w-[40%] overflow-visible bg-neutral-950">
+          <InstructionPanel />
+        </div>
       </div>
-    </div>
+    </ReactQueryProvider>
   );
 }

--- a/src/app/(auth)/request-account/page.tsx
+++ b/src/app/(auth)/request-account/page.tsx
@@ -9,7 +9,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/auth/ui";
-import { Alert } from "@/components/ui/alert";
 import {
   Form,
   FormControl,
@@ -19,11 +18,14 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { requestNewAccount } from "@/lib/accountRequests";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { CheckCircle2, CircleX, Loader2 } from "lucide-react";
+import { useMutation } from "@tanstack/react-query";
+import { CheckCircle2, Loader2 } from "lucide-react";
 import Link from "next/link";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 import { z } from "zod";
 
 const requestAccountSchema = z
@@ -52,9 +54,7 @@ const requestAccountSchema = z
 type RequestAccountValues = z.infer<typeof requestAccountSchema>;
 
 const RequestAccountPage = () => {
-  const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
-  const [loading, setLoading] = useState(false);
 
   const form = useForm<RequestAccountValues>({
     resolver: zodResolver(requestAccountSchema),
@@ -69,29 +69,30 @@ const RequestAccountPage = () => {
 
   const userType = form.watch("userType");
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
+  const requestAccountMutation = useMutation({
+    mutationFn: async (values: RequestAccountValues) => {
+      const result = await requestNewAccount({
+        name: values.name,
+        email: values.email,
+        password: values.password,
+        userType: values.userType === "Admin" ? "ADMIN" : "USER",
+        projectName:
+          values.userType === "Admin" ? values.projectName : undefined,
+      });
 
-    const valid = await form.trigger();
-    if (!valid) return;
+      if (!result.success) {
+        throw new Error(result.error || "Failed to request account.");
+      }
 
-    setLoading(true);
-    setError("");
-
-    /* TODO: Send request to infra team for approval
-    const values = form.getValues();
-    const payload = {
-      name: values.name,
-      email: values.email,
-      password: values.password,
-      userType: values.userType,
-      projectName: values.userType === "Admin" ? values.projectName : undefined,
-    };
-    */
-
-    setSuccess(true);
-    setLoading(false);
-  }
+      return result;
+    },
+    onSuccess: () => setSuccess(true),
+    onError: (error) => {
+      toast.error("Failed to request account", {
+        description: error.message,
+      });
+    },
+  });
 
   if (success) {
     return (
@@ -120,17 +121,14 @@ const RequestAccountPage = () => {
         Request new account
       </h2>
 
-      {error.length > 0 && (
-        <Alert className="mb-4 border-red-500/20 bg-red-500/10">
-          <div className="flex items-center gap-2 text-red-400">
-            <CircleX className="h-4 w-4" />
-            <span className="text-sm">{error}</span>
-          </div>
-        </Alert>
-      )}
-
       <Form {...form}>
-        <form onSubmit={handleSubmit} noValidate className="space-y-4">
+        <form
+          onSubmit={form.handleSubmit((values) =>
+            requestAccountMutation.mutate(values),
+          )}
+          noValidate
+          className="space-y-4"
+        >
           <FormField
             control={form.control}
             name="name"
@@ -233,8 +231,14 @@ const RequestAccountPage = () => {
             />
           )}
 
-          <Button type="submit" className="mt-2 w-full" disabled={loading}>
-            {loading && <Loader2 className="animate-spin" />}
+          <Button
+            type="submit"
+            className="mt-2 w-full"
+            disabled={requestAccountMutation.isPending}
+          >
+            {requestAccountMutation.isPending && (
+              <Loader2 className="animate-spin" />
+            )}
             Request Account
           </Button>
         </form>

--- a/src/components/admin/PendingAccountRequests.tsx
+++ b/src/components/admin/PendingAccountRequests.tsx
@@ -3,7 +3,7 @@
 import { CheckCircle, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -33,7 +33,7 @@ export function PendingAccountRequests() {
   const [processingIds, setProcessingIds] = useState<Set<string>>(new Set());
   const queryClient = useQueryClient();
 
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ["accountRequests"],
     queryFn: getAccountRequests,
   });
@@ -48,21 +48,6 @@ export function PendingAccountRequests() {
         : [],
     [data],
   );
-
-  useEffect(() => {
-    if (isError) {
-      toast.error("Error", {
-        description: `Failed to fetch account requests: ${JSON.stringify(error)}`,
-      });
-      return;
-    }
-
-    if (data && !data.success && data.error) {
-      toast.error("Failed to Fetch Account Requests", {
-        description: data.error,
-      });
-    }
-  }, [data, error, isError]);
 
   const setProcessing = (id: string, processing: boolean) => {
     setProcessingIds((prev) => {

--- a/src/components/admin/PendingAccountRequests.tsx
+++ b/src/components/admin/PendingAccountRequests.tsx
@@ -3,7 +3,7 @@
 import { CheckCircle, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -12,7 +12,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import {
   acceptAccountRequest,
   AccountRequest,
-  declineAccountRequest,
+  deleteAccountRequest,
   getAccountRequests,
 } from "@/lib/accountRequests";
 
@@ -38,13 +38,31 @@ export function PendingAccountRequests() {
     queryFn: getAccountRequests,
   });
 
-  const requests = data?.success ? data.requests : [];
+  const requests = useMemo(
+    () =>
+      data?.success
+        ? [...data.requests].sort(
+            (a, b) =>
+              new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+          )
+        : [],
+    [data],
+  );
 
-  if (isError) {
-    toast.error("Error", {
-      description: `Failed to fetch account requests: ${JSON.stringify(error)}`,
-    });
-  }
+  useEffect(() => {
+    if (isError) {
+      toast.error("Error", {
+        description: `Failed to fetch account requests: ${JSON.stringify(error)}`,
+      });
+      return;
+    }
+
+    if (data && !data.success && data.error) {
+      toast.error("Failed to Fetch Account Requests", {
+        description: data.error,
+      });
+    }
+  }, [data, error, isError]);
 
   const setProcessing = (id: string, processing: boolean) => {
     setProcessingIds((prev) => {
@@ -70,6 +88,7 @@ export function PendingAccountRequests() {
         });
         queryClient.invalidateQueries({ queryKey: ["accountRequests"] });
         queryClient.invalidateQueries({ queryKey: ["users"] });
+        queryClient.invalidateQueries({ queryKey: ["projects"] });
       } else {
         toast.error("Failed to Accept Request", {
           description: result.error ?? "An unexpected error occurred.",
@@ -82,9 +101,9 @@ export function PendingAccountRequests() {
     },
   });
 
-  const declineRequestHandler = useMutation({
+  const deleteRequestHandler = useMutation({
     mutationFn: async (request: AccountRequest) =>
-      declineAccountRequest(request.id),
+      deleteAccountRequest(request.id),
     onMutate: (request) => setProcessing(request.id, true),
     onSuccess: (result, request) => {
       setProcessing(request.id, false);
@@ -136,6 +155,11 @@ export function PendingAccountRequests() {
                 </div>
               ))}
             </div>
+          ) : data && !data.success ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center text-sm text-muted-foreground gap-2">
+              <XCircle className="h-8 w-8 text-muted-foreground/40" />
+              <span>{data.error ?? "Failed to load account requests."}</span>
+            </div>
           ) : requests.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-center text-sm text-muted-foreground gap-2">
               <CheckCircle className="h-8 w-8 text-muted-foreground/40" />
@@ -185,7 +209,7 @@ export function PendingAccountRequests() {
                         size="sm"
                         variant="outline"
                         disabled={isProcessing}
-                        onClick={() => declineRequestHandler.mutate(request)}
+                        onClick={() => deleteRequestHandler.mutate(request)}
                         className="gap-1.5 border-destructive text-destructive hover:bg-destructive hover:text-destructive-foreground"
                       >
                         <XCircle className="h-3.5 w-3.5" />

--- a/src/lib/accountRequests.ts
+++ b/src/lib/accountRequests.ts
@@ -24,6 +24,22 @@ export type AccountRequest = {
   createdAt: string;
 };
 
+type AcceptAccountRequestResult = {
+  success: boolean;
+  error?: string;
+  user?: {
+    id: number;
+    email: string;
+    name: string;
+    type: AccountRequestRole;
+    projectIds?: number[];
+  };
+  project?: {
+    id: number;
+    name: string;
+  };
+};
+
 export async function requestNewAccount(data: RequestNewAccountInput): Promise<{
   success: boolean;
   error?: string;
@@ -127,21 +143,51 @@ export async function deleteAccountRequest(id: string): Promise<{
   }
 }
 
-export async function acceptAccountRequest(request: AccountRequest): Promise<{
-  success: boolean;
-  error?: string;
-}> {
-  console.log("acceptAccountRequest", request);
-  return {
-    success: false,
-    error:
-      "Accepting account requests is not supported yet because the API does not expose an approval route or the stored request password.",
-  };
-}
+export async function acceptAccountRequest(
+  request: AccountRequest,
+): Promise<AcceptAccountRequestResult> {
+  const session = await getSession();
+  if (!session) return { success: false, error: "Unauthorized" };
 
-export async function declineAccountRequest(id: string): Promise<{
-  success: boolean;
-  error?: string;
-}> {
-  return deleteAccountRequest(id);
+  if (!requireAdmin(session.user)) {
+    return { success: false, error: "Only admins can manage account requests" };
+  }
+
+  if (!request.id.trim()) {
+    return { success: false, error: "Account request ID is required" };
+  }
+
+  try {
+    const juno = getJunoInstance();
+    const result = await juno.auth.acceptAccountRequest({
+      id: request.id,
+      credentials: session.jwt,
+    });
+
+    return {
+      success: true,
+      user: {
+        id: result.user.id,
+        email: result.user.email,
+        name: result.user.name,
+        type: String(result.user.type) as unknown as AccountRequestRole,
+        projectIds: result.user.projectIds,
+      },
+      project: result.project
+        ? {
+            id: result.project.id,
+            name: result.project.name,
+          }
+        : undefined,
+    };
+  } catch (error) {
+    console.error("Error accepting account request:", error);
+    return {
+      success: false,
+      error:
+        error?.body?.message ||
+        error?.message ||
+        "Failed to accept account request.",
+    };
+  }
 }

--- a/src/lib/accountRequests.ts
+++ b/src/lib/accountRequests.ts
@@ -52,7 +52,6 @@ export async function requestNewAccount(data: RequestNewAccountInput): Promise<{
       success: true,
     };
   } catch (error) {
-    console.error("Error requesting new account:", error.body);
     return {
       success: false,
       error:
@@ -97,7 +96,6 @@ export async function getAccountRequests(): Promise<{
       })),
     };
   } catch (error) {
-    console.error("Error fetching account requests:", error);
     return {
       success: false,
       requests: [],
@@ -132,7 +130,6 @@ export async function deleteAccountRequest(id: string): Promise<{
     });
     return { success: true };
   } catch (error) {
-    console.error("Error deleting account request:", error);
     return {
       success: false,
       error:
@@ -181,7 +178,6 @@ export async function acceptAccountRequest(
         : undefined,
     };
   } catch (error) {
-    console.error("Error accepting account request:", error);
     return {
       success: false,
       error:

--- a/src/lib/accountRequests.ts
+++ b/src/lib/accountRequests.ts
@@ -1,25 +1,52 @@
 "use server";
 
-import {
-  createUserAction,
-  createProjectAction,
-  linkUserToProject,
-} from "./actions";
+import { UserType } from "juno-sdk/build/main/lib/auth";
+import { getJunoInstance } from "./juno";
 import { getSession } from "./session";
 import { requireAdmin } from "./auth";
 
 export type AccountRequestRole = "ADMIN" | "USER" | "SUPERADMIN";
 
+type RequestNewAccountInput = {
+  email: string;
+  name: string;
+  password: string;
+  userType: UserType;
+  projectName?: string;
+};
+
 export type AccountRequest = {
   id: string;
   email: string;
   name: string;
-  password: string;
   userType: AccountRequestRole;
   projectName?: string;
+  createdAt: string;
 };
 
-// PLACEHOLDER: replace with real SDK call
+export async function requestNewAccount(data: RequestNewAccountInput): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const juno = getJunoInstance();
+    await juno.auth.requestNewAccount(data);
+
+    return {
+      success: true,
+    };
+  } catch (error) {
+    console.error("Error requesting new account:", error.body);
+    return {
+      success: false,
+      error:
+        error?.body?.message ||
+        error?.message ||
+        "Failed to request new account.",
+    };
+  }
+}
+
 export async function getAccountRequests(): Promise<{
   success: boolean;
   requests: AccountRequest[];
@@ -36,37 +63,36 @@ export async function getAccountRequests(): Promise<{
     };
   }
 
-  return {
-    success: true,
-    requests: [
-      {
-        id: "1",
-        name: "Alice Johnson",
-        email: "alice.johnson@example.com",
-        password: "placeholder",
-        userType: "ADMIN",
-        projectName: "Apollo",
-      },
-      {
-        id: "2",
-        name: "Marcus Lee",
-        email: "marcus.lee@example.com",
-        password: "placeholder",
-        userType: "USER",
-      },
-      {
-        id: "3",
-        name: "Priya Nair",
-        email: "priya.nair@example.com",
-        password: "placeholder",
-        userType: "ADMIN",
-        projectName: "Hermes",
-      },
-    ],
-  };
+  try {
+    const juno = getJunoInstance();
+    const result = await juno.auth.getAllAccountRequests({
+      credentials: session.jwt,
+    });
+
+    return {
+      success: true,
+      requests: (result.requests || []).map((request) => ({
+        id: String(request.id),
+        email: request.email,
+        name: request.name,
+        userType: String(request.userType) as unknown as AccountRequestRole,
+        projectName: request.projectName,
+        createdAt: request.createdAt,
+      })),
+    };
+  } catch (error) {
+    console.error("Error fetching account requests:", error);
+    return {
+      success: false,
+      requests: [],
+      error:
+        error?.body?.message ||
+        error?.message ||
+        "Failed to fetch account requests.",
+    };
+  }
 }
 
-// PLACEHOLDER: replace with real SDK call
 export async function deleteAccountRequest(id: string): Promise<{
   success: boolean;
   error?: string;
@@ -78,61 +104,39 @@ export async function deleteAccountRequest(id: string): Promise<{
     return { success: false, error: "Only admins can manage account requests" };
   }
 
-  const success = id === id;
-  return { success };
+  if (!id.trim()) {
+    return { success: false, error: "Account request ID is required" };
+  }
+
+  try {
+    const juno = getJunoInstance();
+    await juno.auth.deleteAccountRequest({
+      id,
+      credentials: session.jwt,
+    });
+    return { success: true };
+  } catch (error) {
+    console.error("Error deleting account request:", error);
+    return {
+      success: false,
+      error:
+        error?.body?.message ||
+        error?.message ||
+        "Failed to delete account request.",
+    };
+  }
 }
 
 export async function acceptAccountRequest(request: AccountRequest): Promise<{
   success: boolean;
   error?: string;
 }> {
-  const userResult = await createUserAction({
-    name: request.name,
-    email: request.email,
-    password: request.password,
-  });
-
-  if (!userResult.success) {
-    const raw = String(userResult.error ?? "");
-    const errorMessage = raw.includes("ALREADY_EXISTS")
-      ? `An account with the email ${request.email} already exists.`
-      : "An unexpected error occurred while creating the account. Please try again.";
-    return { success: false, error: errorMessage };
-  }
-
-  if (request.userType === "ADMIN" && request.projectName) {
-    const projectResult = await createProjectAction({
-      projectName: request.projectName,
-    });
-
-    if (!projectResult.success) {
-      return {
-        success: false,
-        error: `User created but failed to create project: ${projectResult.error}`,
-      };
-    }
-
-    const linkResult = await linkUserToProject({
-      projectName: request.projectName,
-      userId: String(userResult.user.id),
-    });
-
-    if (!linkResult.success) {
-      return {
-        success: false,
-        error: `User and project created but failed to link them: ${linkResult.error}`,
-      };
-    }
-  }
-
-  const deleteResult = await deleteAccountRequest(request.id);
-  if (!deleteResult.success) {
-    console.error(
-      `Failed to delete account request ${request.id}: ${deleteResult.error}`,
-    );
-  }
-
-  return { success: true };
+  console.log("acceptAccountRequest", request);
+  return {
+    success: false,
+    error:
+      "Accepting account requests is not supported yet because the API does not expose an approval route or the stored request password.",
+  };
 }
 
 export async function declineAccountRequest(id: string): Promise<{


### PR DESCRIPTION
Closes #77 
Connected request new account frontend and view/accept/decline requests frontend to their SDK methods by updating `accountRequests.ts` to use the SDK methods rather than placeholders, and updating the frontend to properly use the functions in `accountRequests.ts`, so requesting new accounts and accepting/declining requests works end to end.

Depends on https://github.com/GTBitsOfGood/juno-sdk/pull/73 and https://github.com/GTBitsOfGood/juno/pull/245 being merged first.

Video Demo of both accepting and declining new account requests:

https://github.com/user-attachments/assets/f3738525-7e6d-431a-b4ea-21798ef29907

